### PR TITLE
Improved path to recognize script from role

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Resolve redirect early for Python < 2.7.9
-  script: files/resolve-redirect.sh {{ ansible_python_version }} {{ go_download_location }}
+  script: resolve-redirect.sh {{ ansible_python_version }} {{ go_download_location }}
   register: go_download_location_adjusted
 
 - name: Download the Go tarball


### PR DESCRIPTION
 Ansible will look into `role/files` by itself. That's why the first part of the path is not necessary. 
Also, with the `files/` part in there, it raises the error:
`input file not found at /vagrant/provisioning/roles/golang/files/files/resolve-redirect.sh or /vagrant/provisioning/files/resolve-redirect.sh`  since it is trying to find the script in `files/files/resolve-redirect.sh` ir in the direct inventory path. 

That shouldn't be an issue anymore and it would support any folder structure =) 
